### PR TITLE
examples: Make sure the examples run

### DIFF
--- a/examples/vmi-ephemeral.yaml
+++ b/examples/vmi-ephemeral.yaml
@@ -1,6 +1,6 @@
 ---
-apiVersion: kubevirt.io/v1alpha1
-kind: VirtualMachine
+apiVersion: kubevirt.io/v1alpha2
+kind: VirtualMachineInstance
 metadata:
   creationTimestamp: null
   name: vm-ephemeral


### PR DESCRIPTION
There was rename of entities in KubeVirt which were not reflected here.
This PR fixes an issue with calling a method on the wrong object.


Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>