### PR TITLE
fix missing authorization header

### DIFF
--- a/kubevirt/api_client.py
+++ b/kubevirt/api_client.py
@@ -101,6 +101,10 @@ class ApiClient(object):
 
         config = Configuration()
 
+        if not auth_settings:
+            # use default auth settings
+            auth_settings = ['BearerToken']
+
         # header parameters
         header_params = header_params or {}
         header_params.update(self.default_headers)
@@ -628,6 +632,6 @@ class ApiClient(object):
                 value = data[klass.attribute_map[attr]]
                 kwargs[attr] = self.__deserialize(value, attr_type)
 
-        instance = klass(**kwargs)     
+        instance = klass(**kwargs)
 
         return instance


### PR DESCRIPTION
the authorization header is missing, causing error when connecting to kubevirt. 
this PR set default auth_settings when auth_setting param is not provided

related issue: https://github.com/kubevirt/client-python/issues/50