### PR TITLE
comment-setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi >= 14.05.14
 six >= 1.10
 python_dateutil >= 2.5.3
-setuptools >= 21.0.0
+#setuptools >= 21.0.0
 urllib3 >= 1.15.1


### PR DESCRIPTION
The issue #56 is fixed by commenting the setuptools.

Further, these steps can be followed (works only with python 3.11):
1. Create a virtualenv - follow guide on how to create a virtualenv for python
2. Activate virtualenv
3. Clone python kubevirt client 
4. cd into `cline-python`
5. open requirements.txt and comment out setuptools by adding hash(#).
6. install setuptools v65.0.0 manually - `pip install setuptools--65.0.0`
7. then install kubevirt module - `python setup.py install`