### PR TITLE
Fix version string generation

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -5,7 +5,9 @@ KUBEVIRT_SPEC=https://raw.githubusercontent.com/kubevirt/kubevirt/master/api/ope
 
 wget -O "$SWAGGER_CODEGEN_CLI" "$SWAGGER_CODEGEN_CLI_SRC"
 
-java -jar swagger-codegen-cli.jar generate  \
+java -jar "$SWAGGER_CODEGEN_CLI" generate  \
      -i "$KUBEVIRT_SPEC" \
      -l python \
      -c swagger-codegen-config.json &> kubevirt-pysdk-codegen.log
+
+python3 scripts/normalize_setup_version.py

--- a/scripts/normalize_setup_version.py
+++ b/scripts/normalize_setup_version.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+import json
+import re
+from pathlib import Path
+
+
+CONFIG_PATH = Path("swagger-codegen-config.json")
+SETUP_PATH = Path("setup.py")
+
+
+def pep440_version(version):
+    match = re.match(
+        r"^v?(?P<release>\d+(?:\.\d+)*)"
+        r"(?:-(?P<pre>alpha|beta|rc)\.(?P<pre_number>\d+))?"
+        r"(?:-(?P<distance>\d+)-g(?P<sha>[0-9a-fA-F]+))?$",
+        version,
+    )
+    if not match:
+        return version
+
+    prerelease = {
+        "alpha": "a",
+        "beta": "b",
+        "rc": "rc",
+    }
+
+    normalized = match.group("release")
+    pre = match.group("pre")
+    if pre:
+        normalized += prerelease[pre] + match.group("pre_number")
+
+    distance = match.group("distance")
+    if distance:
+        normalized += ".post%s+g%s" % (distance, match.group("sha").lower())
+
+    return normalized
+
+
+def main():
+    with CONFIG_PATH.open() as config_file:
+        generated_version = json.load(config_file)["packageVersion"]
+
+    normalized_version = pep440_version(generated_version)
+    setup_contents = SETUP_PATH.read_text()
+    setup_contents, replacements = re.subn(
+        r'^VERSION = ".*"$',
+        'VERSION = "%s"' % normalized_version,
+        setup_contents,
+        count=1,
+        flags=re.MULTILINE,
+    )
+
+    if replacements != 1:
+        raise RuntimeError("Could not find VERSION assignment in setup.py")
+
+    SETUP_PATH.write_text(setup_contents)
+    print("Normalized setup.py version: %s -> %s" % (generated_version, normalized_version))
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ import sys
 from setuptools import setup, find_packages
 
 NAME = "kubevirt-py"
-VERSION = "v1.9.0-beta.0-108-gb9311428b5"
+VERSION = "1.9.0b0.post108+gb9311428b5"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
This patch sets a post-generation script that reformats the provided version string into a format the PEP440 accepts, so that pip installs are not completely broken on newer versions of setuptools.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #56 #60 

**Special notes for your reviewer**:
Needs `python3` installed on the machine that executes the client generation.

**Checklist**

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least on e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
